### PR TITLE
Using correct string length for non ASCII runes

### DIFF
--- a/levenshtein.go
+++ b/levenshtein.go
@@ -15,8 +15,8 @@ package levenshtein
 // http://en.wikibooks.org/wiki/Algorithm_implementation/Strings/Levenshtein_distance#C
 func Distance(s1, s2 string) int {
 	var cost, lastdiag, olddiag int
-	len_s1 := len(s1)
-	len_s2 := len(s2)
+	len_s1 := len([]rune(s1))
+	len_s2 := len([]rune(s2))
 
 	column := make([]int, len_s1+1)
 

--- a/levenshtein_test.go
+++ b/levenshtein_test.go
@@ -21,6 +21,7 @@ var distanceTests = []struct {
 	{"ab", "aaa", 2},
 	{"bbb", "a", 3},
 	{"kitten", "sitting", 3},
+	{"aa", "aü", 2},
 }
 
 func TestDistance(t *testing.T) {


### PR DESCRIPTION
Hi,

thank you for creating the library! 
I've run into an issue with german umlauts. They have two bytes per character. But the distance should still be 1 per character.
This pull request fixes it.
The solution is taken from http://stackoverflow.com/questions/12668681/go-language-string-length
