### PR TITLE
Minor improvements, shorten + coding style

### DIFF
--- a/levenshtein.go
+++ b/levenshtein.go
@@ -4,7 +4,7 @@
 
 package levenshtein
 
-// The Levenshtein distance between two strings is defined as the minimum
+// Distance - The Levenshtein distance between two strings is defined as the minimum
 // number of edits needed to transform one string into the other, with the
 // allowable edit operations being insertion, deletion, or substitution of
 // a single character

--- a/levenshtein.go
+++ b/levenshtein.go
@@ -14,47 +14,34 @@ package levenshtein
 // It is based on the optimized C version found here:
 // http://en.wikibooks.org/wiki/Algorithm_implementation/Strings/Levenshtein_distance#C
 func Distance(str1, str2 string) int {
-	var cost, lastdiag, olddiag int
-	s1 := []rune(str1)
-	s2 := []rune(str2)
+	s1, s2 := []rune(str1), []rune(str2)
+	lenS1, lenS2 := len(s1), len(s2)
+	column := make([]int, lenS1+1)
 
-	len_s1 := len(s1)
-	len_s2 := len(s2)
-
-	column := make([]int, len_s1+1)
-
-	for y := 1; y <= len_s1; y++ {
-		column[y] = y
+	for i := range column {
+		column[i] = i // initialise, in case lenS2 is empty
 	}
+	column[0] = lenS2 // in case str1 is empty
 
-	for x := 1; x <= len_s2; x++ {
-		column[0] = x
-		lastdiag = x - 1
-		for y := 1; y <= len_s1; y++ {
-			olddiag = column[y]
-			cost = 0
-			if s1[y-1] != s2[x-1] {
+	for x := 0; x < lenS2; x++ {
+		lastdiag := x
+		for y := 0; y < lenS1; y++ {
+			cost := 0
+			if s1[y] != s2[x] {
 				cost = 1
 			}
-			column[y] = min(
-				column[y]+1,
-				column[y-1]+1,
-				lastdiag+cost)
-			lastdiag = olddiag
+			lastdiag, column[y+1] = column[y+1], min(column[y+1]+1, column[y]+1, lastdiag+cost)
 		}
 	}
-	return column[len_s1]
+	return column[lenS1]
 }
 
 func min(a, b, c int) int {
-	if a < b {
-		if a < c {
-			return a
-		}
-	} else {
-		if b < c {
-			return b
-		}
+	if a < b && a < c {
+		return a
+	}
+	if b < c && b < a {
+		return b
 	}
 	return c
 }

--- a/levenshtein_test.go
+++ b/levenshtein_test.go
@@ -14,6 +14,8 @@ var distanceTests = []struct {
 	second string
 	wanted int
 }{
+	{"e", "", 1},
+	{"", "e", 1},
 	{"a", "a", 0},
 	{"ab", "ab", 0},
 	{"ab", "aa", 1},


### PR DESCRIPTION
Commit messages say it all really:

- Rename snake_cased variables to the preferred camelCase style
- Remove redundant variables, use in-place reassignments
- replace first loop with range + initialise `column[0]` outside of loop instead of reassigning
- simplified the `min` implementation (possible because it's not using varargs)
- added a couple of comments for clarification
- added test cases for empty strings
- exported function docs should start with the function name (for godoc)